### PR TITLE
bump app version in tauri conf

### DIFF
--- a/tauri.conf.json
+++ b/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2.0.0",
   "productName": "LaReview",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "identifier": "dev.lareview",
   "build": {
     "beforeDevCommand": {


### PR DESCRIPTION
Fixes #5 

I think moving the `v0.0.30` tag to this commit would trigger a release that would upload the artifacts to the latest release.