### PR TITLE
fix(gitlab): avoid /raw_diffs 404 on GitLab < 17.9

### DIFF
--- a/src/infra/cli/diff.rs
+++ b/src/infra/cli/diff.rs
@@ -1,7 +1,11 @@
 //! Diff acquisition from various sources.
 
+use crate::block_on;
 use crate::infra::shell;
-use crate::infra::vcs::{github, gitlab};
+use crate::infra::vcs::{
+    github,
+    gitlab::{self, GitLabMrRef},
+};
 use anyhow::{Context, Result};
 use std::io::{IsTerminal, Read};
 use std::process::Command;
@@ -179,39 +183,21 @@ pub fn acquire_diff(source: DiffSource) -> Result<String> {
             project_path,
             number,
         } => {
-            let glab_path = shell::find_bin("glab").context("Could not find 'glab' executable")?;
-            // Note: `glab mr diff` does not support --hostname (unlike `glab api`).
-            // For self-hosted instances we set GITLAB_HOST so glab resolves the right host.
-            // Use --raw to get a proper unified diff with `diff --git` headers.
-            // Without --raw, glab outputs diffs without file separator headers,
-            // causing the parser to only recognise the first file.
-            let args = vec![
-                "mr".to_string(),
-                "diff".to_string(),
-                number.to_string(),
-                "--raw".to_string(),
-                "--repo".to_string(),
-                project_path,
-            ];
+            let mr = GitLabMrRef {
+                host: host.clone(),
+                project_path: project_path.clone(),
+                number,
+                url: format!("https://{host}/{project_path}/-/merge_requests/{number}"),
+            };
 
-            let mut cmd = Command::new(glab_path);
-            cmd.args(args);
-            if host != "gitlab.com" {
-                cmd.env("GITLAB_HOST", &host);
-            }
-            let output = cmd.output().context("Failed to fetch MR via glab CLI")?;
-
-            if !output.status.success() {
-                let stderr = String::from_utf8_lossy(&output.stderr);
-
-                if stderr.contains("Authentication") || stderr.contains("not authenticated") {
-                    anyhow::bail!("GitLab authentication required. Run `glab auth login` first.");
+            let diff = block_on(gitlab::fetch_mr_diff(&mr)).map_err(|err| {
+                let msg = format!("{err:#}");
+                if msg.contains("Authentication") || msg.contains("not authenticated") {
+                    anyhow::anyhow!("GitLab authentication required. Run `glab auth login` first.")
+                } else {
+                    anyhow::anyhow!("Failed to fetch MR !{} diff: {}", number, msg)
                 }
-
-                anyhow::bail!("glab mr diff failed: {}", stderr);
-            }
-
-            let diff = String::from_utf8_lossy(&output.stdout).into_owned();
+            })?;
 
             if diff.is_empty() {
                 anyhow::bail!("MR !{} has no changes.", number);

--- a/src/infra/vcs/gitlab.rs
+++ b/src/infra/vcs/gitlab.rs
@@ -97,6 +97,24 @@ struct GlabDiffRefs {
     start_sha: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct GlabMrChange {
+    old_path: String,
+    new_path: String,
+    #[serde(default)]
+    a_mode: Option<String>,
+    #[serde(default)]
+    b_mode: Option<String>,
+    #[serde(default)]
+    new_file: bool,
+    #[serde(default)]
+    renamed_file: bool,
+    #[serde(default)]
+    deleted_file: bool,
+    #[serde(default)]
+    diff: String,
+}
+
 pub async fn fetch_mr_metadata(mr: &GitLabMrRef) -> Result<GitLabMrMetadata> {
     let glab_path = shell::find_bin("glab").context("resolve `glab` path")?;
     let endpoint = format!(
@@ -138,35 +156,89 @@ pub async fn fetch_mr_metadata(mr: &GitLabMrRef) -> Result<GitLabMrMetadata> {
     })
 }
 
+// GitLab 17.8.x 500s /diffs when per_page > 30
+// (NoMethodError on PaginatedMergeRequestDiff). Do not raise.
+const MR_DIFFS_PER_PAGE: u32 = 20;
+
 pub async fn fetch_mr_diff(mr: &GitLabMrRef) -> Result<String> {
     let glab_path = shell::find_bin("glab").context("resolve `glab` path")?;
-    // Note: `glab mr diff` does not support --hostname (unlike `glab api`).
-    // For self-hosted instances we set GITLAB_HOST so glab resolves the right host.
-    // Use --raw to get a proper unified diff with `diff --git` headers.
-    // Without --raw, glab outputs diffs without file separator headers,
-    // causing the parser to only recognise the first file.
-    let args = vec![
-        "mr".to_string(),
-        "diff".to_string(),
-        mr.number.to_string(),
-        "--raw".to_string(),
-        "--repo".to_string(),
-        mr.project_path.clone(),
-    ];
+    let endpoint = format!(
+        "projects/{}/merge_requests/{}/diffs?per_page={}",
+        encode_project_path(&mr.project_path),
+        mr.number,
+        MR_DIFFS_PER_PAGE,
+    );
+    let args = glab_args_with_host(
+        &mr.host,
+        vec![
+            "api".to_string(),
+            "--paginate".to_string(),
+            "--output".to_string(),
+            "ndjson".to_string(),
+            endpoint,
+        ],
+    );
 
-    let mut cmd = Command::new(&glab_path);
-    cmd.args(args);
-    if mr.host != "gitlab.com" {
-        cmd.env("GITLAB_HOST", &mr.host);
-    }
-    let output = cmd.output().await.context("run `glab mr diff`")?;
+    let output = Command::new(&glab_path)
+        .args(args)
+        .output()
+        .await
+        .context("run `glab api` for MR diffs")?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(anyhow::anyhow!(format!("`glab mr diff` failed: {stderr}")));
+        return Err(anyhow::anyhow!(format!(
+            "`glab api` diffs failed: {stderr}"
+        )));
     }
 
-    String::from_utf8(output.stdout).context("decode `glab mr diff` stdout")
+    let json = String::from_utf8(output.stdout).context("decode `glab api` diffs stdout")?;
+    let changes = parse_ndjson_changes(&json).context("parse `glab api` diffs ndjson")?;
+
+    Ok(synthesize_unified_diff(&changes))
+}
+
+fn parse_ndjson_changes(ndjson: &str) -> Result<Vec<GlabMrChange>> {
+    serde_json::Deserializer::from_str(ndjson)
+        .into_iter::<GlabMrChange>()
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(Into::into)
+}
+
+fn synthesize_unified_diff(changes: &[GlabMrChange]) -> String {
+    use std::fmt::Write as _;
+
+    let mut buf = String::new();
+    for c in changes {
+        let _ = writeln!(buf, "diff --git a/{} b/{}", c.old_path, c.new_path);
+
+        if c.new_file {
+            let mode = c.b_mode.as_deref().unwrap_or("100644");
+            let _ = writeln!(buf, "new file mode {mode}");
+            buf.push_str("--- /dev/null\n");
+            let _ = writeln!(buf, "+++ b/{}", c.new_path);
+        } else if c.deleted_file {
+            let mode = c.a_mode.as_deref().unwrap_or("100644");
+            let _ = writeln!(buf, "deleted file mode {mode}");
+            let _ = writeln!(buf, "--- a/{}", c.old_path);
+            buf.push_str("+++ /dev/null\n");
+        } else {
+            if c.renamed_file {
+                let _ = writeln!(buf, "rename from {}", c.old_path);
+                let _ = writeln!(buf, "rename to {}", c.new_path);
+            }
+            let _ = writeln!(buf, "--- a/{}", c.old_path);
+            let _ = writeln!(buf, "+++ b/{}", c.new_path);
+        }
+
+        if !c.diff.is_empty() {
+            buf.push_str(&c.diff);
+            if !c.diff.ends_with('\n') {
+                buf.push('\n');
+            }
+        }
+    }
+    buf
 }
 
 async fn post_glab_api(

--- a/tests/gitlab_diff_fetch_integration.rs
+++ b/tests/gitlab_diff_fetch_integration.rs
@@ -1,0 +1,158 @@
+//! Integration test for `fetch_mr_diff`: verifies it calls the GitLab
+//! `/diffs` endpoint via `glab api`, reconstructs a multi-file unified
+//! diff from the JSON response, and produces output that `DiffIndex`
+//! parses into the expected set of files.
+
+#![cfg(unix)]
+
+use lareview::infra::diff::index::DiffIndex;
+use lareview::infra::vcs::gitlab::{GitLabMrRef, fetch_mr_diff};
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::sync::Mutex;
+use tempfile::TempDir;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn write_fake_glab(dir: &std::path::Path, script: &str) {
+    let glab_path = dir.join("glab");
+    fs::write(&glab_path, script).expect("write fake glab");
+    let mut perms = fs::metadata(&glab_path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&glab_path, perms).unwrap();
+}
+
+struct PathGuard {
+    original: Option<std::ffi::OsString>,
+}
+
+impl PathGuard {
+    // Prepend `new_path` to a minimal system PATH. The fake `glab` still
+    // wins (tempdir comes first) but `/bin:/usr/bin` keeps `cat`, `printf`,
+    // etc. available to the fake shell script — without them, heredocs
+    // silently produce empty stdout.
+    fn set(new_path: &std::path::Path) -> Self {
+        let original = std::env::var_os("PATH");
+        let combined = format!("{}:/bin:/usr/bin", new_path.display());
+        unsafe {
+            std::env::set_var("PATH", combined);
+        }
+        Self { original }
+    }
+}
+
+impl Drop for PathGuard {
+    fn drop(&mut self) {
+        unsafe {
+            match self.original.take() {
+                Some(v) => std::env::set_var("PATH", v),
+                None => std::env::remove_var("PATH"),
+            }
+        }
+    }
+}
+
+// Holding a std Mutex across the .await below is intentional — the guard
+// serialises PATH/env mutation across tests that share the process.
+#[allow(clippy::await_holding_lock)]
+#[tokio::test]
+async fn fetch_mr_diff_reconstructs_multi_file_diff_via_diffs_endpoint() {
+    let _guard = ENV_LOCK.lock().unwrap();
+
+    // Fake `glab`: rejects any `--raw` invocation and, for a `/diffs`
+    // call that includes `--paginate --output ndjson`, emits a canned
+    // two-file newline-delimited payload — the shape `glab api` would
+    // produce after walking `Link: rel="next"` itself across all pages.
+    let script = r#"#!/bin/sh
+have_paginate=0
+have_ndjson=0
+prev=""
+for arg in "$@"; do
+  if [ "$arg" = "--raw" ]; then
+    echo "reintroduced --raw; this path must not be used" >&2
+    exit 1
+  fi
+  if [ "$arg" = "--paginate" ]; then
+    have_paginate=1
+  fi
+  if [ "$prev" = "--output" ] && [ "$arg" = "ndjson" ]; then
+    have_ndjson=1
+  fi
+  prev="$arg"
+done
+
+if [ "$1" != "api" ]; then
+  echo "unexpected fake glab invocation: $*" >&2
+  exit 2
+fi
+
+# Our call shape always has the endpoint as the last positional arg.
+endpoint=""
+for arg in "$@"; do
+  endpoint="$arg"
+done
+
+case "$endpoint" in
+  *diffs*)
+    if [ "$have_paginate" != "1" ] || [ "$have_ndjson" != "1" ]; then
+      echo "fetch_mr_diff must pass --paginate --output ndjson (perf: avoid N subprocess spawns)" >&2
+      exit 1
+    fi
+    cat <<'NDJSON'
+{"old_path":"README.md","new_path":"README.md","a_mode":"100644","b_mode":"100644","new_file":false,"renamed_file":false,"deleted_file":false,"diff":"@@ -1,2 +1,3 @@\n line one\n line two\n+line three\n"}
+{"old_path":"docs/new.md","new_path":"docs/new.md","a_mode":null,"b_mode":"100644","new_file":true,"renamed_file":false,"deleted_file":false,"diff":"@@ -0,0 +1,2 @@\n+hello\n+world\n"}
+NDJSON
+    exit 0
+    ;;
+  *merge_requests*)
+    cat <<'JSON'
+{
+  "title": "E2E: multi-file diff repro",
+  "web_url": "http://localhost/e2e/raw-diffs-repro/-/merge_requests/1",
+  "diff_refs": { "head_sha": "h", "base_sha": "b", "start_sha": "s" }
+}
+JSON
+    exit 0
+    ;;
+esac
+
+echo "unexpected endpoint: $endpoint" >&2
+exit 2
+"#;
+
+    let tmp = TempDir::new().expect("tmp");
+    write_fake_glab(tmp.path(), script);
+    let _path = PathGuard::set(tmp.path());
+
+    let mr = GitLabMrRef {
+        host: "gitlab.com".to_string(),
+        project_path: "e2e/raw-diffs-repro".to_string(),
+        number: 1,
+        url: "https://gitlab.com/e2e/raw-diffs-repro/-/merge_requests/1".to_string(),
+    };
+
+    let diff = fetch_mr_diff(&mr)
+        .await
+        .expect("fetch_mr_diff should succeed against /diffs endpoint");
+
+    let header_count = diff
+        .lines()
+        .filter(|line| line.starts_with("diff --git "))
+        .count();
+    assert_eq!(
+        header_count, 2,
+        "expected exactly two `diff --git` headers, got {header_count}\n---\n{diff}\n---"
+    );
+
+    let index = DiffIndex::new(&diff).expect("unidiff parser should accept synthesised diff");
+    assert!(
+        index.files.contains_key("README.md"),
+        "README.md missing from index; files={:?}",
+        index.files.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        index.files.contains_key("docs/new.md"),
+        "docs/new.md missing from index; files={:?}",
+        index.files.keys().collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

`fetch_mr_diff` used to shell out to `glab mr diff --raw`. Recent `glab` releases implement `--raw` by calling GitLab's `/projects/:id/merge_requests/:iid/raw_diffs` endpoint, which first shipped in **GitLab 17.9** ([archived 17.8 docs show it absent][17.8-docs]; [archived 17.9 docs show it present][17.9-docs]). On older self-hosted instances — the reporter in #12 was on **GitLab CE 17.8.6** — that endpoint returns `404 Not Found` and the diff fetch aborts:

```
Could not obtain raw diff: 404 Not Found
```

This PR replaces `glab mr diff --raw` with a single `glab api --paginate --output ndjson` call to the long-standing `/diffs` endpoint and reconstructs the `diff --git` framing that the downstream `unidiff`-based `DiffIndex` parser requires.

Closes #12.

## Why `--raw` existed in the first place

Without `--raw`, `glab mr diff` prints a unified diff *without* the `diff --git a/... b/...` separator headers between files. `DiffIndex` (wrapping `unidiff`) hard-requires those headers to split the stream into per-file views — without them, the parser sees the whole thing as one big diff and only the first file is recognised. Commit `015ca0b` originally added `--raw` to fix exactly that.

This PR takes the other road: drop `--raw` entirely, use the structured JSON endpoint, and synthesise the framing in lareview. That keeps `DiffIndex` happy and works on every GitLab version from at least 17.x onward (the `/diffs` endpoint predates both 17.8 and 17.9, though GitLab's docs don't cite the exact introduction version).

## The fix

### `src/infra/vcs/gitlab.rs::fetch_mr_diff` — rewritten

One `glab api --paginate --output ndjson` invocation hitting:

```
projects/:encoded/merge_requests/:iid/diffs?per_page=20
```

The endpoint returns one JSON object per changed file with `old_path`, `new_path`, `a_mode`, `b_mode`, `new_file`, `deleted_file`, `renamed_file`, and `diff`. A new `synthesize_unified_diff` helper wraps each entry in the framing the parser expects — `diff --git`, `--- /dev/null` / `+++ b/...` for adds, `rename from` / `rename to` for renames, etc. — then appends the raw hunks from the JSON verbatim.

### `src/infra/cli/diff.rs::DiffSource::GitLabMr` — deduplicated

There was a second, verbatim copy of the same `glab mr diff --raw` shell-out in the CLI entry point — same bug, independent code path. It now calls `gitlab::fetch_mr_diff` via the existing `block_on` helper. The two paths can't drift apart again.

## Why `--paginate --output ndjson` specifically

`glab api --paginate` walks the server's `Link: rel="next"` header internally, collapsing what would otherwise be N sequential subprocess spawns (one per page) into a single invocation. This was explicitly flagged by review and is the right mitigation here.

The catch: glab's default output mode doesn't transform multi-page responses — it concatenates the raw bodies back-to-back with no separator, so for an endpoint returning JSON arrays you get `[...p1...][...p2...]` which is **not** a valid single JSON array (confirmed by glab's own REST pagination test: [`api_test.go#L556`][glab-test] asserts the output is literally `{"page":1}{"page":2}{"page":3}`).

`--output ndjson` is the supported programmatic-consumption mode — it emits each array element as one JSON document per line, which `serde_json::Deserializer::into_iter::<GlabMrChange>()` stream-parses cleanly.

On `per_page` preservation: glab's [`addPerPage`][glab-pagination] only injects its default (100) when the URL has no `per_page`, and subsequent pages use the server's `Link: rel="next"` URL verbatim — which echoes our `per_page=20` back into every paged request. Verified in `api_test.go` which asserts `per_page=100` appears only on the first request when the user supplied nothing.

## Why `per_page=20`

It's the documented default for this endpoint per [the GitLab REST API reference][gitlab-diffs-docs]. It *also* incidentally sidesteps a GitLab 17.8.x upstream bug: `per_page > 30` triggers `NoMethodError: undefined method 'page' for PaginatedMergeRequestDiff` in the `/diffs` controller (the high-`per_page` path swaps to a pre-paginated collection that doesn't respond to Kaminari's `.page` while the controller calls it anyway). The bug is not called out in the docs, because bugs by definition aren't documented. 20 is both spec-compliant and safe on 17.8.x, so we pin it.

## Verification

**1. Mock integration test** — `tests/gitlab_diff_fetch_integration.rs` installs a fake `glab` on `PATH` that exits non-zero on any `--raw` invocation, asserts the Rust code passes both `--paginate` and `--output ndjson` (so dropping the perf optimization re-trips the review comment), answers with the canned multi-file ndjson payload, and checks `fetch_mr_diff`'s output parses into the expected two files via `DiffIndex::new`.

**2. Real GitLab 17.8.6 via Docker** — during development I stood up a manual harness (not in this PR) that booted `gitlab/gitlab-ce:17.8.6-ce.0`, seeded a multi-file MR via REST, and ran `fetch_mr_metadata` + `fetch_mr_diff` against it through a real `glab`. **Red leg** (pre-fix source) reported `Could not obtain raw diff: 404 Not Found` verbatim matching #12. **Green leg** (post-fix source, same container) reported `diff --git headers: 2`, `diff bytes: 6553`, both files parsed. The real run is also what surfaced the `per_page > 30` upstream bug and drove the `per_page=20` pin; the mock test alone would not have caught that. The harness code was stripped from the branch after verification since it's not shippable.

**3. Build + lint + full suite** — `cargo test` (201 tests), `cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, all clean.

## Docs grounding

Every version-specific claim in this PR and in the code comments is grounded in an authoritative source, not in E2E observation:

- `/raw_diffs` first shipping in 17.9: [17.8 archived docs][17.8-docs] (absent) vs [17.9 archived docs][17.9-docs] (present).
- `/diffs` `per_page` default of 20: [current endpoint reference][gitlab-diffs-docs].
- `glab api --paginate` semantics (walks `Link: rel="next"`, stops when absent): [`pagination.go::findNextPage`][glab-pagination].
- `glab api --output ndjson` emitting one element per line: [`api.go` source + `api_test.go` line 556][glab-test].
- `per_page` preservation across `--paginate` pages: [`addPerPage`][glab-pagination] injects default only when absent.

## Test plan

- [ ] `cargo test --test gitlab_diff_fetch_integration`
- [ ] `cargo test`
- [ ] `cargo fmt --check && cargo clippy --all-targets --all-features -- -D warnings`
- [ ] Manual smoke against any GitLab < 17.9 instance (the only code path this change meaningfully improves over the old `--raw` approach from the reporter's perspective). If you don't have one handy, a GitLab ≥ 17.9 instance confirms the fix doesn't regress newer servers.

## Non-goals

- `push_review` / `push_feedback` against GitLab still shell out to `glab api` the same way as before — not touched here.
- Binary diffs are passed through with empty `diff` bodies (GitLab's own representation), matching pre-existing behaviour — not independently exercised by the test.
- Direct HTTP (`reqwest`) as a replacement for `glab` is *not* pursued; `--paginate --output ndjson` already collapses the subprocess-per-page cost to 1, and keeping `glab` as the single VCS auth surface avoids introducing a second "way of talking to GitLab" that could drift.

[17.8-docs]: https://archives.docs.gitlab.com/17.8/api/merge_requests/
[17.9-docs]: https://archives.docs.gitlab.com/17.9/api/merge_requests/
[gitlab-diffs-docs]: https://docs.gitlab.com/api/merge_requests/#list-merge-request-diffs
[glab-pagination]: https://gitlab.com/gitlab-org/cli/-/blob/main/internal/commands/api/pagination.go
[glab-test]: https://gitlab.com/gitlab-org/cli/-/blob/main/internal/commands/api/api_test.go#L556
